### PR TITLE
Fix duplicated field in QORAAL configuration

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -25,7 +25,15 @@ SVC_SERVICE_DECL("engine", engine_service_ctrl, 0, QORAAL_SERVICE_ENGINE, SVC_SE
 SVC_SERVICE_RUN_DECL("www",  wserver_service_run, wserver_service_ctrl, 0, 6000, OS_THREAD_PRIO_4, QORAAL_SERVICE_WWW, SVC_SERVICE_FLAGS_AUTOSTART)
 SVC_SERVICE_LIST_END()
 
-static const QORAAL_CFG_T           _qoraal_cfg = { .malloc = platform_malloc, .free = platform_free, .debug_print = platform_print, .debug_assert = platform_assert, .current_time = platform_current_time, .rand = platform_rand, .rand = platform_rand, .wdt_kick = platform_wdt_kick};
+static const QORAAL_CFG_T           _qoraal_cfg = {
+    .malloc       = platform_malloc,
+    .free         = platform_free,
+    .debug_print  = platform_print,
+    .debug_assert = platform_assert,
+    .current_time = platform_current_time,
+    .rand         = platform_rand,
+    .wdt_kick     = platform_wdt_kick
+};
 
 /*===========================================================================*/
 /* Local Functions                                                           */


### PR DESCRIPTION
## Summary
- remove duplicate `.rand` initializer in `src/main.c`
- expand formatting for readability

## Testing
- `cmake ..` *(fails: unable to clone repository)*

------
https://chatgpt.com/codex/tasks/task_e_6853b3e333d0832294c6d8d9c04ab92d